### PR TITLE
Add note to explicitly start C++ client

### DIFF
--- a/hello/cpp/README.md
+++ b/hello/cpp/README.md
@@ -18,6 +18,12 @@ Start Crossbar by doing:
 crossbar start
 ```
 
+Start the C++ client by doing:
+
+```shell
+./hello
+```
+
 Open [`http://localhost:8080/`](http://localhost:8080/) (or wherever Crossbar runs) in your browser.
 
 ## How to hack


### PR DESCRIPTION
Could also just invoke `hello` from the router config, but not doing so makes it nicer to run the https://github.com/tavendo/AutobahnCpp examples, by giving them a "clean" router to use.
