### PR TITLE
Make votes app work with Python backend

### DIFF
--- a/votes/browser/js/frontend.js
+++ b/votes/browser/js/frontend.js
@@ -1,7 +1,7 @@
 // the URL of the WAMP Router (Crossbar.io)
 //
 var wsuri;
-if (document.location.origin == "file://") {
+if (document.location.origin === "null" || document.location.origin === "file://") {
    wsuri = "ws://127.0.0.1:8080/ws";
 
 } else {

--- a/votes/python/.crossbar/config.json
+++ b/votes/python/.crossbar/config.json
@@ -9,7 +9,7 @@
          },
          "realms": [
             {
-               "name": "realm1",
+               "name": "votesapp",
                "roles": [
                   {
                      "name": "anonymous",
@@ -48,7 +48,7 @@
             {
                "type": "class",
                "classname": "votes.VotesBackend",
-               "realm": "realm1",
+               "realm": "votesapp",
                "role": "anonymous"
             }
          ]


### PR DESCRIPTION
Corrected realm name to 'votesapp' in Python votes backend.
Made wsuri calculation work under Firefox 37.0.2.

Fixes #12.
