### PR TITLE
Fix a typo.

### DIFF
--- a/django/realtimemonitor/client.py
+++ b/django/realtimemonitor/client.py
@@ -92,7 +92,7 @@ s.close()
 
 @app.signal('onjoined')
 @inlineCallbacks
-def called_on_joinded():
+def called_on_joined():
     """ Loop sending the state of this machine using WAMP every x seconds.
 
         This function is executed when the client joins the router, which


### PR DESCRIPTION
Even though the name of the function seems irrelevant, now its name is in accordance with the @app.signal decorator's argument.
