### PR TITLE
fix node path.

### DIFF
--- a/authenticate/wampcradynamic/nodejs/.crossbar/config.json
+++ b/authenticate/wampcradynamic/nodejs/.crossbar/config.json
@@ -107,7 +107,7 @@
       },
       {
          "type": "guest",
-         "executable": "/usr/bin/node",
+         "executable": "node",
          "arguments": [
             "authenticator.js",
             "ws://127.0.0.1:9000",
@@ -121,7 +121,7 @@
       },
       {
          "type": "guest",
-         "executable": "/usr/bin/node",
+         "executable": "node",
          "arguments": [
             "backend.js",
             "ws://127.0.0.1:9000",


### PR DESCRIPTION
We don't need absolute path when using `nvm` node package management.
