### PR TITLE
[bugfix] Django1.10 not support old style URL patterns

### DIFF
--- a/django/realtimemonitor/django_project/urls.py
+++ b/django/realtimemonitor/django_project/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import url
 from django.contrib import admin
 from django.views.generic import TemplateView
+from django_app import views
 
-urlpatterns = patterns('',
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^clients/', 'django_app.views.clients'),
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+    url(r'^clients/', views.clients),
     url(r'^$', TemplateView.as_view(template_name='dashboard.html')),
-)
+]


### PR DESCRIPTION
when i run the demo "realtimemonitor" some error happened

```
2016-08-05T11:46:04+0800 [Router      21299] Internal Server Error: /clients/
2016-08-05T11:46:04+0800 [Router      21299] Traceback (most recent call last):
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/exception.py", line 39, i


n inner


2016-08-05T11:46:04+0800 [Router      21299]     response = get_response(request)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
2016-08-05T11:46:04+0800 [Router      21299]     response = self._get_response(request)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/base.py", line 172, in _get_response
2016-08-05T11:46:04+0800 [Router      21299]     resolver_match = resolver.resolve(request.path_info)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/urls/resolvers.py", line 267, in resolve
2016-08-05T11:46:04+0800 [Router      21299]     for pattern in self.url_patterns:
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/utils/functional.py", line 35, in __get__
2016-08-05T11:46:04+0800 [Router      21299]     res = instance.__dict__[self.name] = self.func(instance)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/urls/resolvers.py", line 310, in url_patterns
2016-08-05T11:46:04+0800 [Router      21299]     patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/utils/functional.py", line 35, in __get__
2016-08-05T11:46:04+0800 [Router      21299]     res = instance.__dict__[self.name] = self.func(instance)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/urls/resolvers.py", line 303, in urlconf_module
2016-08-05T11:46:04+0800 [Router      21299]     return import_module(self.urlconf_name)
2016-08-05T11:46:04+0800 [Router      21299]   File "/opt/rh/python27/root/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
2016-08-05T11:46:04+0800 [Router      21299]     __import__(name)
2016-08-05T11:46:04+0800 [Router      21299]   File "/data/crossbarexamples/django/realtimemonitor/django_project/urls.py", line 1, in <module>
2016-08-05T11:46:04+0800 [Router      21299]     from django.conf.urls import patterns, include, url
2016-08-05T11:46:04+0800 [Router      21299] ImportError: cannot import name patterns
```

the I readed [Django1.10 tutorial ](https://docs.djangoproject.com/en/1.10/intro/tutorial01/#write-your-first-view) and modified.
