### PR TITLE
Django1.10 runing error fix 

### DIFF
--- a/django/realtimemonitor/django_project/settings.py
+++ b/django/realtimemonitor/django_project/settings.py
@@ -64,6 +64,17 @@ DATABASES = {
     }
 }
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            # ... some options here ...
+        },
+    },
+]
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/
 


### PR DESCRIPTION
When I run demo "realtimemonitor" , error happened

```
2016-08-05T11:58:43+0800 [Router      21977] Internal Server Error: /
2016-08-05T11:58:43+0800 [Router      21977] Traceback (most recent call last):
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/exception.py", line 39, r
2016-08-05T11:58:43+0800 [Router      21977]     response = get_response(request)
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/base.py", line 249, in _e
2016-08-05T11:58:43+0800 [Router      21977]     response = self._get_response(request)
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/base.py", line 217, in _e
2016-08-05T11:58:43+0800 [Router      21977]     response = self.process_exception_by_middleware(e, request)
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/core/handlers/base.py", line 215, in _e
2016-08-05T11:58:43+0800 [Router      21977]     response = response.render()
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/template/response.py", line 109, in rer
2016-08-05T11:58:43+0800 [Router      21977]     self.content = self.rendered_content
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/template/response.py", line 84, in rent


2016-08-05T11:58:43+0800 [Router      21977]     template = self.resolve_template(self.template_name)
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/template/response.py", line 66, in rese
2016-08-05T11:58:43+0800 [Router      21977]     return select_template(template, using=self.using)
2016-08-05T11:58:43+0800 [Router      21977]   File "/opt/rh/python27/root/usr/lib64/python2.7/site-packages/django/template/loader.py", line 53, in selece
2016-08-05T11:58:43+0800 [Router      21977]     raise TemplateDoesNotExist(', '.join(template_name_list), chain=chain)
2016-08-05T11:58:43+0800 [Router      21977] TemplateDoesNotExist: dashboard.html

```

then add TEMPLATES to django settings, it worked well.
