### PR TITLE
fix permissions

### DIFF
--- a/authorization/dynamic/embedded/.crossbar/config.json
+++ b/authorization/dynamic/embedded/.crossbar/config.json
@@ -17,7 +17,7 @@
                                     "uri": "com.example.auth",
                                     "match": "exact",
                                     "allow": {
-                                        "call": true
+                                        "register": true
                                     }
                                 }
                             ]

--- a/authorization/dynamic/embedded/authorizer.py
+++ b/authorization/dynamic/embedded/authorizer.py
@@ -9,4 +9,9 @@ class Authorizer(ApplicationSession):
 
     def authorize(self, session, uri, action):
         self.log.info('authorize: session={session}, uri={uri}, action={action}', session=session, uri=uri, action=action)
-        return True
+        # you can just return True/False here, which is a shortcut for {"allow": True/False}
+        return {
+            "allow": True,
+            "cache": False,  # optional
+            "disclose": True,  # optional
+        }


### PR DESCRIPTION
The config for the embedded example was wrong, and I also updated the example to show the `dict` that authorizers can return
