### PR TITLE
Crossbar v20.4.1 'adapter' package should be 'bridge' now

### DIFF
--- a/rest/subscriber/.crossbar/config.json
+++ b/rest/subscriber/.crossbar/config.json
@@ -68,7 +68,7 @@
             "components": [
                 {
                     "type": "class",
-                    "classname": "crossbar.adapter.rest.MessageForwarder",
+                    "classname": "crossbar.bridge.rest.MessageForwarder",
                     "realm": "realm1",
                     "extra": {
                         "subscriptions": [


### PR DESCRIPTION
Crossbar v20.4.1 does not have the adapter package and when I saw the packaging it turns out to be bridge.  For this reason the http subscriber example doesn't run.