### PR TITLE
Crossbar v20.4.1 'adapter' package should be 'bridge' now for rest\callee example

### DIFF
--- a/rest/callee/.crossbar/config.json
+++ b/rest/callee/.crossbar/config.json
@@ -68,7 +68,7 @@
             "components": [
                 {
                     "type": "class",
-                    "classname": "crossbar.adapter.rest.RESTCallee",
+                    "classname": "crossbar.bridge.rest.RESTCallee",
                     "realm": "realm1",
                     "extra": {
                         "procedure": "com.myapp.rest",


### PR DESCRIPTION
Similar to https://github.com/crossbario/crossbar-examples/pull/139 , this also needs a change to work for rest\callee example (HTTP Bridge)